### PR TITLE
Replaced Class#newInstance method with Constructor#newInstance method

### DIFF
--- a/src/main/java/com/poiji/bind/mapping/PoijiHandler.java
+++ b/src/main/java/com/poiji/bind/mapping/PoijiHandler.java
@@ -4,6 +4,7 @@ import com.poiji.annotation.ExcelCell;
 import com.poiji.exception.IllegalCastException;
 import com.poiji.option.PoijiOptions;
 import com.poiji.util.Casting;
+import java.lang.reflect.InvocationTargetException;
 import org.apache.poi.ss.util.CellAddress;
 import org.apache.poi.xssf.usermodel.XSSFComment;
 
@@ -40,8 +41,8 @@ final class PoijiHandler<T> implements SheetContentsHandler {
     private <T> T newInstanceOf(Class<T> type) {
         T newInstance;
         try {
-            newInstance = type.newInstance();
-        } catch (IllegalAccessException | InstantiationException e) {
+            newInstance = type.getDeclaredConstructor().newInstance();
+        } catch (NoSuchMethodException| InvocationTargetException | IllegalAccessException | InstantiationException e) {
             throw new IllegalCastException("Cannot create a new instance of " + type.getName());
         }
 
@@ -65,7 +66,6 @@ final class PoijiHandler<T> implements SheetContentsHandler {
 
                 if (column == index.value()) {
 
-                    if (!field.isAccessible())
                         field.setAccessible(true);
 
                     Object o = Casting.castValue(fieldType, content, options);


### PR DESCRIPTION
The Class#newInstance method creates an instance but by-passes some checked exceptions (NoSuchMethod and InvocationTargetException) which could otherwise be caught by the compiler.
This PR also removes the method Field#isAccessible() and preemptively calls the Field#setAccessible(true) method since all fields created from Class#getDeclaredFields() have the accessible flag set to false.
The Class#newInstance method and the Field#isAccessible() are also deprecated in java 9