### PR TITLE
Allow user to return null instead of default date

### DIFF
--- a/src/main/java/com/poiji/option/PoijiOptions.java
+++ b/src/main/java/com/poiji/option/PoijiOptions.java
@@ -9,6 +9,7 @@ public final class PoijiOptions {
 
     private int skip;
     private String datePattern;
+    private boolean preferNullOverDefault;
     private int sheetIndex;
 
     private PoijiOptions() {
@@ -25,6 +26,11 @@ public final class PoijiOptions {
         return this;
     }
 
+    private PoijiOptions setPreferNullOverDefault(boolean preferNullOverDefault) {
+        this.preferNullOverDefault = preferNullOverDefault;
+        return this;
+    }
+
     private PoijiOptions setSheetIndex(int sheetIndex) {
         this.sheetIndex = sheetIndex;
         return this;
@@ -36,6 +42,10 @@ public final class PoijiOptions {
 
     public String datePattern() {
         return datePattern;
+    }
+
+    public boolean preferNullOverDefault() {
+        return preferNullOverDefault;
     }
 
     /**
@@ -51,6 +61,7 @@ public final class PoijiOptions {
 
         private int skip = 1;
         private String datePattern = DEFAULT_DATE_PATTERN;
+        private boolean preferNullOverDefault = false;
         private int sheetIndex;
 
         private PoijiOptionsBuilder() {
@@ -63,6 +74,7 @@ public final class PoijiOptions {
         public PoijiOptions build() {
             return new PoijiOptions()
                     .setSkip(skip)
+                    .setPreferNullOverDefault(preferNullOverDefault)
                     .setDatePattern(datePattern)
                     .setSheetIndex(sheetIndex);
         }
@@ -79,6 +91,17 @@ public final class PoijiOptions {
          */
         public PoijiOptionsBuilder datePattern(String datePattern) {
             this.datePattern = datePattern;
+            return this;
+        }
+
+        /**
+         * set whether or not to use null instead of default object
+         *
+         * @param preferNullOverDefault boolean
+         * @return this
+         */
+        public PoijiOptionsBuilder preferNullOverDefault(boolean preferNullOverDefault) {
+            this.preferNullOverDefault = preferNullOverDefault;
             return this;
         }
 

--- a/src/main/java/com/poiji/util/Casting.java
+++ b/src/main/java/com/poiji/util/Casting.java
@@ -59,8 +59,12 @@ public final class Casting {
             final SimpleDateFormat sdf = new SimpleDateFormat(options.datePattern());
             return sdf.parse(value);
         } catch (ParseException e) {
-            Calendar calendar = Calendar.getInstance();
-            return calendar.getTime();
+            if (Boolean.TRUE.equals(options.preferNullOverDefault())) {
+                return null;
+            } else {
+                Calendar calendar = Calendar.getInstance();
+                return calendar.getTime();
+            }
         }
     }
 


### PR DESCRIPTION
Because java.util.Date is an object, we should allow a user to return null if the parsing fails, instead of default to a date.