### PR TITLE
Fix for #105 : fix and optimize column lookup code

### DIFF
--- a/src/main/java/com/poiji/bind/mapping/PoijiHandler.java
+++ b/src/main/java/com/poiji/bind/mapping/PoijiHandler.java
@@ -160,7 +160,6 @@ final class PoijiHandler<T> implements SheetContentsHandler {
                if (column == index.value()) {
                    Object o = casting.castValue(fieldType, content, internalCount, column, options);
                    setFieldData(field, o, ins);
-                    return column;
                }
                return index.value();
            } else {

--- a/src/main/java/com/poiji/bind/mapping/PoijiHandler.java
+++ b/src/main/java/com/poiji/bind/mapping/PoijiHandler.java
@@ -81,7 +81,7 @@ final class PoijiHandler<T> implements SheetContentsHandler {
     }
 
     private boolean setValue(String content, Class<? super T> type, int column) {
-        boolean valueSet = false;
+        
         // For ExcelRow annotation
         if(columnToField.containsKey(-1)) {
             Field field = columnToField.get(-1);
@@ -93,21 +93,15 @@ final class PoijiHandler<T> implements SheetContentsHandler {
             if (columnToSuperClassField.containsKey(column)) {
                 Object ins = null;
                 ins = getInstance(columnToSuperClassField.get(column));
-                int columnForField = setValue(field, column, content, ins);
-
-                if (columnForField!=NOT_POIJI_COLUMN && columnForField == column) {
-                    setFieldData(columnToSuperClassField.get(column), ins, instance);
-                    valueSet = true;
-                }
-
+                setValue(field, column, content, ins);
+                setFieldData(columnToSuperClassField.get(column), ins, instance);
             } else {
-                int columnForField = setValue(field, column, content, instance);
-                if( columnForField != NOT_POIJI_COLUMN && columnForField == column)
-                        valueSet = true;
+                setValue(field, column, content, instance);
             }
+            return true;
         }
 
-        if(valueSet) return true;
+        boolean valueSet = false;
 
         for (Field field : type.getDeclaredFields()) {
 

--- a/src/main/java/com/poiji/bind/mapping/XSSFUnmarshaller.java
+++ b/src/main/java/com/poiji/bind/mapping/XSSFUnmarshaller.java
@@ -28,8 +28,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-import static org.apache.poi.xssf.eventusermodel.XSSFReader.SheetIterator;
-
 /**
  * Created by hakan on 22/10/2017
  */


### PR DESCRIPTION
Fix some code and added few comments.

some benchmark :-

**Note** :-  Ran on my  `core i3 5005U`  `4gb ram`  machine.

**Initially** ran all unit tests on average *26* seconds
**After** optimizing ran all unit tests on average *20* seconds

Though we aren't still using column maps for optimization for *HSSF* sheets which would further improve the unit test run time.