### PR TITLE
Feature fix for #44 : Skip every second row support

### DIFF
--- a/src/main/java/com/poiji/bind/mapping/HSSFUnmarshaller.java
+++ b/src/main/java/com/poiji/bind/mapping/HSSFUnmarshaller.java
@@ -60,7 +60,7 @@ abstract class HSSFUnmarshaller implements Unmarshaller {
         for (Row currentRow : sheet) {
             if (!skip(currentRow, skip) && !isRowEmpty(currentRow)) {
             	
-            	if(currentRow.getRowNum() + 1  >= limit)
+            	if(currentRow.getRowNum() > limit)
                     return;
                 T t = deserialize0(currentRow, type);
                 consumer.accept(t);

--- a/src/main/java/com/poiji/bind/mapping/PoijiHandler.java
+++ b/src/main/java/com/poiji/bind/mapping/PoijiHandler.java
@@ -197,11 +197,11 @@ final class PoijiHandler<T> implements SheetContentsHandler {
             titles.put(formattedValue, column);
         }
 
-        if (row + 1 <= options.skip()) {
+        if (row < options.skip()) {
             return;
         }
-
-        if (row +1 >= limit)
+        
+        if (row > limit)
                 throw new LimitCrossedException("Limit crossed, Stop Iteration");
 
         setFieldValue(formattedValue, type, column);

--- a/src/main/java/com/poiji/option/PoijiOptions.java
+++ b/src/main/java/com/poiji/option/PoijiOptions.java
@@ -257,7 +257,7 @@ public final class PoijiOptions {
                     .setDateLenient(dateLenient)
                     .setHeaderStart(headerStart)
                     .setCasting(casting)
-                    .setLimit(limit == Integer.MAX_VALUE ? limit : limit + headerStart + 1);
+                    .setLimit(limit == Integer.MAX_VALUE ? limit : limit + skip + headerStart);
         }
 
         /**

--- a/src/main/java/com/poiji/option/PoijiOptions.java
+++ b/src/main/java/com/poiji/option/PoijiOptions.java
@@ -17,6 +17,8 @@ public final class PoijiOptions {
 
     private int skip;
     private int limit;
+    private int readEvery;
+    private int skipEvery;
     private int sheetIndex;
     private String password;
     private String dateRegex;
@@ -40,15 +42,33 @@ public final class PoijiOptions {
     }
 
     public int getLimit() {
-		return limit;
-	}
+        return limit;
+    }
 
-	public PoijiOptions setLimit(int limit) {
-		this.limit = limit;
-		return this;
-	}
+    public PoijiOptions setLimit(int limit) {
+        this.limit = limit;
+        return this;
+    }
 
-	private PoijiOptions setDatePattern(String datePattern) {
+    public int getReadEvery() {
+        return readEvery;
+    }
+
+    public int getSkipEvery() {
+        return skipEvery;
+    }
+
+    private PoijiOptions setReadEvery(int readEvery) {
+        this.readEvery = readEvery;
+        return this;
+    }
+
+    private PoijiOptions setSkipEvery(int skipEvery) {
+        this.skipEvery = skipEvery;
+        return this;
+    }
+
+    private PoijiOptions setDatePattern(String datePattern) {
         this.datePattern = datePattern;
         return this;
     }
@@ -168,6 +188,8 @@ public final class PoijiOptions {
     public static class PoijiOptionsBuilder {
 
         private int limit=Integer.MAX_VALUE;
+        private int readEvery=1;
+        private int skipEvery=0;
         private int sheetIndex;
         private String password;
         private String dateRegex;
@@ -257,7 +279,9 @@ public final class PoijiOptions {
                     .setDateLenient(dateLenient)
                     .setHeaderStart(headerStart)
                     .setCasting(casting)
-                    .setLimit(limit == Integer.MAX_VALUE ? limit : limit + skip + headerStart);
+                    .setLimit(limit == Integer.MAX_VALUE ? limit : limit + skip + headerStart)
+                    .setReadEvery(skipEvery == 0 ? 1 : readEvery)
+                    .setSkipEvery(skipEvery);
         }
 
         /**
@@ -279,7 +303,7 @@ public final class PoijiOptions {
          * 
          * @param sheetName
          * @return
-         */	
+         */
         public PoijiOptionsBuilder sheetName(String sheetName) {
             this.sheetName = sheetName;
             return this;
@@ -308,9 +332,32 @@ public final class PoijiOptions {
 
         public PoijiOptionsBuilder limit(int limit) {
             if(limit<0) {
-	            throw new PoijiException("limit must be greater than or equal to 0");
+                throw new PoijiException("limit must be greater than or equal to 0");
             }
             this.limit = limit;
+            return this;
+        }
+
+        /**
+        *  Alternate reads and skip. The header & skipped rows from top are not counted.
+        *
+        *  Note:- Available rows to read are between skip and limit options;
+        *
+        * @param readEvery
+        * specifies how many rows to read without skipping
+        *
+        * @param skipEvery
+        * specifies how many rows to skip after the rows read
+        *
+        * @return this
+        */
+
+        public PoijiOptionsBuilder jumpReads(int readEvery,int skipEvery) {
+            if(skipEvery<0 || readEvery<1) {
+                throw new PoijiException("skipEvery must be greater 0 and readEvery must be greater 1");  
+            }
+            this.readEvery = readEvery;
+            this.skipEvery = skipEvery;
             return this;
         }
 

--- a/src/test/java/com/poiji/deserialize/ReadUptoLimitTest.java
+++ b/src/test/java/com/poiji/deserialize/ReadUptoLimitTest.java
@@ -33,11 +33,11 @@ public class ReadUptoLimitTest {
 
 		List<Person> personListFromXSSF = Poiji.fromExcel(new File("src/test/resources/person.xlsx"), Person.class,
 				options);
-		assertEquals(3, personListFromXSSF.size());
+		assertEquals(4, personListFromXSSF.size());
 
 		List<Person> personListFromHSSF = Poiji.fromExcel(new File("src/test/resources/person.xls"), Person.class,
 				options);
-		assertEquals(3, personListFromHSSF.size());
+		assertEquals(4, personListFromHSSF.size());
 
 	}
 
@@ -48,11 +48,11 @@ public class ReadUptoLimitTest {
 
 		List<Person> personListFromXSSF = Poiji.fromExcel(new File("src/test/resources/person.xlsx"), Person.class,
 				options);
-		assertEquals(1, personListFromXSSF.size());
+		assertEquals(3, personListFromXSSF.size());
 
 		List<Person> personListFromHSSF = Poiji.fromExcel(new File("src/test/resources/person.xls"), Person.class,
 				options);
-		assertEquals(1, personListFromHSSF.size());
+		assertEquals(3, personListFromHSSF.size());
 	}
 
 	@Test(expected = PoijiException.class)

--- a/src/test/java/com/poiji/deserialize/SkipReadsTest.java
+++ b/src/test/java/com/poiji/deserialize/SkipReadsTest.java
@@ -1,0 +1,77 @@
+package com.poiji.deserialize;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.poiji.bind.Poiji;
+import com.poiji.deserialize.model.byid.Person;
+import com.poiji.exception.PoijiException;
+import com.poiji.option.PoijiOptions;
+import com.poiji.option.PoijiOptions.PoijiOptionsBuilder;
+
+public class SkipReadsTest {
+
+	@Test
+	public void testWithDefaultsShouldReadAll() {
+
+		List<Person> actualEmployees = Poiji.fromExcel(new File("src/test/resources/person.xlsx"), Person.class);
+
+		assertEquals(5, actualEmployees.size());
+
+		actualEmployees = Poiji.fromExcel(new File("src/test/resources/person.xls"), Person.class);
+
+		assertEquals(5, actualEmployees.size());
+	}
+
+	@Test
+	public void testWithoutAnyLimitOrSkip() {
+
+		PoijiOptions options = PoijiOptionsBuilder.settings().jumpReads(2, 1).build();
+		List<Person> actualEmployees = Poiji.fromExcel(new File("src/test/resources/person.xlsx"), Person.class,
+				options);
+
+		assertEquals(4, actualEmployees.size());
+
+		actualEmployees = Poiji.fromExcel(new File("src/test/resources/person.xls"), Person.class, options);
+
+		assertEquals(4, actualEmployees.size());
+	}
+
+	@Test
+	public void testWithoutLimitWithSkipEveryZeroShouldReadAllRows() {
+
+		PoijiOptions options = PoijiOptionsBuilder.settings().jumpReads(3, 0).build();
+		List<Person> actualEmployees = Poiji.fromExcel(new File("src/test/resources/person.xlsx"), Person.class,
+				options);
+
+		assertEquals(5, actualEmployees.size());
+
+		actualEmployees = Poiji.fromExcel(new File("src/test/resources/person.xls"), Person.class, options);
+
+		assertEquals(5, actualEmployees.size());
+	}
+
+	@Test
+	public void testWithLimitAndSkip() {
+
+		PoijiOptions options = PoijiOptionsBuilder.settings().skip(1).limit(3).jumpReads(1, 1).build();
+		List<Person> actualEmployees = Poiji.fromExcel(new File("src/test/resources/person.xlsx"), Person.class,
+				options);
+
+		assertEquals(2, actualEmployees.size());
+
+		actualEmployees = Poiji.fromExcel(new File("src/test/resources/person.xls"), Person.class, options);
+
+		assertEquals(2, actualEmployees.size());
+	}
+
+	@Test(expected = PoijiException.class)
+	public void testWithNotSuitingValueShouldThrowException() {
+		PoijiOptionsBuilder.settings().jumpReads(0, -1).build();	
+	}
+
+}


### PR DESCRIPTION
By specifying `jumpReads(readEvery,skipEvery)` in options  we can read particular rows, and skip rows after that read, so on and so forth, until `limit` is reached (if specified or end of the sheet)