### PR TITLE
Check for blank cell type in addition to null check for mandatory cells

### DIFF
--- a/src/main/java/com/poiji/bind/mapping/HSSFUnmarshaller.java
+++ b/src/main/java/com/poiji/bind/mapping/HSSFUnmarshaller.java
@@ -324,7 +324,7 @@ abstract class HSSFUnmarshaller extends PoijiWorkBook implements Unmarshaller {
             FieldAnnotationDetail annotationDetail) {
         Cell cell = currentRow.getCell(annotationDetail.getColumn());
 
-        if (cell != null) {
+        if (cell != null && cell.getCellType() != CellType.BLANK) {
             if (annotationDetail.isDisabledCellFormat()) {
                 cell.setCellStyle(null);
             }

--- a/src/test/java/com/poiji/deserialize/MandatoryCellsExceptionTest.java
+++ b/src/test/java/com/poiji/deserialize/MandatoryCellsExceptionTest.java
@@ -12,6 +12,8 @@ import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 import java.util.List;
@@ -19,12 +21,24 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+@RunWith(Parameterized.class)
 public class MandatoryCellsExceptionTest {
+
+    private final Sheet sheet;
+
+    public MandatoryCellsExceptionTest(Sheet sheet) {
+        this.sheet = sheet;
+    }
+
+    @Parameterized.Parameters
+    public static List<Sheet> sheets() {
+        return List.of(createDummyExcel(true), createDummyExcel(false));
+    }
 
     @Test
     public void testExcelMandatoryColumn() {
         try {
-            Poiji.fromExcel(createDummyExcel(), MandatoryMissingCells.class, PoijiOptions.PoijiOptionsBuilder
+            Poiji.fromExcel(sheet, MandatoryMissingCells.class, PoijiOptions.PoijiOptionsBuilder
                     .settings()
                     .build());
         } catch (PoijiMultiRowException e) {
@@ -38,7 +52,7 @@ public class MandatoryCellsExceptionTest {
         fail("Expected exception: " + PoijiMultiRowException.class.getName());
     }
 
-    private Sheet createDummyExcel() {
+    private static Sheet createDummyExcel(boolean addBlank) {
 
         Workbook workbook = new HSSFWorkbook();
         Sheet sheet = workbook.createSheet("Example");
@@ -52,6 +66,10 @@ public class MandatoryCellsExceptionTest {
         Row dataRow = sheet.createRow(1);
         Cell dataCell1 = dataRow.createCell(0);
         dataCell1.setCellValue("Paul");
+        if (addBlank) {
+            Cell dataCell2 = dataRow.createCell(1);
+            dataCell2.setBlank();
+        }
 
         try {
             workbook.close();


### PR DESCRIPTION
This change adds a check if the cell is blank, i.e. is not missing / `null`, but having `CellType.BLANK`.

This improves mandatory cell check behavior as described in #311 , and blank cells in XLS files and opened XLS/XLSX sheets also throw a `PoijiMultiRowException`.