### PR TITLE
Add module-info.java for Java Platform Module System support

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,14 @@
+module com.poiji {
+    requires java.xml;
+    requires org.apache.poi.poi;
+    requires org.apache.poi.ooxml;
+    requires org.apache.commons.collections4;
+
+    exports com.poiji.annotation;
+    exports com.poiji.bind;
+    exports com.poiji.config;
+    exports com.poiji.exception;
+    exports com.poiji.option;
+    exports com.poiji.parser;
+    exports com.poiji.util;
+}


### PR DESCRIPTION
## Summary
Adds `module-info.java` to enable Java Platform Module System (JPMS) support for the library.

## Changes
- Added `src/main/java/module-info.java` declaring the `com.poiji` module
- Module requires: `java.xml`, `org.apache.poi.poi`, `org.apache.poi.ooxml`, `org.apache.commons.collections4`
- Module exports: all public API packages (`com.poiji.annotation`, `com.poiji.bind`, `com.poiji.config`, `com.poiji.exception`, `com.poiji.option`, `com.poiji.parser`, `com.poiji.util`)

## Motivation
Since Poiji is Java 11 based and Apache POI is already modularized, adding module-info.java improves compatibility with modular applications and follows modern Java best practices.

Closes #341